### PR TITLE
Propose error improvement

### DIFF
--- a/src/LiveApi.js
+++ b/src/LiveApi.js
@@ -113,7 +113,9 @@ export default class LiveApi {
             if (!json.error) {
                 promise.resolve(json);
             } else {
-                promise.reject(json.error);
+                const err = json.error;
+                err.request = json.echo_req;
+                promise.reject(err);
             }
         }
     }


### PR DESCRIPTION
Please do not merge yet ~

Wish to discuss with you, I think it's beneficial to include request when rejecting Promise, this will make developer easier to pin point problematic request

What do you think ?
If we're going to deprecate echo_req, we might need to store req before promise is resolved.