### PR TITLE
Do not call resubscribe by default

### DIFF
--- a/src/LiveApi.js
+++ b/src/LiveApi.js
@@ -55,8 +55,6 @@ export default class LiveApi {
         this.socket.onclose = ::this.onClose;
         this.socket.onerror = ::this.onError;
         this.socket.onmessage = ::this.onMessage;
-
-        this.resubscribe();
     }
 
     disconnect() {
@@ -106,6 +104,7 @@ export default class LiveApi {
         this.socket.close();
         this.language = ln;
         this.connect();
+        this.resubscribe();
     }
 
     isReady() {
@@ -131,6 +130,7 @@ export default class LiveApi {
 
     onClose() {
         this.connect();
+        this.resubscribe();
     }
 
     onError(error) {


### PR DESCRIPTION
Resubscribe in connect() will cause duplicated calls on load.

T0        => Connection not open yet, next-gen make dozens of call
T0 +1   => Those call are accumulated in buffer, and which does trigger the `bindCallsAndStateMutators`
T0 +2   => Connection opened, some calls are called twice.


Question:
Should I resubscribe in onError?