### PR TITLE
Don't send request where parameters are missing

### DIFF
--- a/src/LiveApi.js
+++ b/src/LiveApi.js
@@ -212,7 +212,7 @@ export default class LiveApi {
     }
 
     send(json) {
-        if (Object.keys(json).length === 0) {
+        if (Object.keys(json).length === 0 && json.constructor === Object) {
             return;
         }
         const reqId = Math.floor((Math.random() * 1e15));

--- a/src/LiveApi.js
+++ b/src/LiveApi.js
@@ -212,6 +212,9 @@ export default class LiveApi {
     }
 
     send(json) {
+        if (Object.keys(json).length === 0) {
+            return;
+        }
         const reqId = Math.floor((Math.random() * 1e15));
         return this.sendRaw({
             req_id: reqId,


### PR DESCRIPTION
Hi,

Attached contained few changes that would restrict our api call when the params are missing. 