### PR TITLE
Updated the unsubscribes in read to match newest ver

### DIFF
--- a/src/calls/read.js
+++ b/src/calls/read.js
@@ -42,8 +42,7 @@ export const subscribeToBalance = () => ({
 });
 
 export const unsubscribeFromBalance = () => ({
-    balance: 1,
-    subscribe: 0,
+    forget_all: 'balance',
 });
 
 export const subscribeToOpenContract = (contractId: number) => ({
@@ -63,8 +62,7 @@ export const subscribeToAllOpenContracts = () => ({
 });
 
 export const unsubscribeFromAllOpenContracts = () => ({
-    proposal_open_contract: 1,
-    subscribe: 0,
+    forget_all: 'proposal_open_contract',
 });
 
 export const subscribeToTransactions = () => ({
@@ -73,6 +71,5 @@ export const subscribeToTransactions = () => ({
 });
 
 export const unsubscribeFromTransactions = () => ({
-    transaction: 1,
-    subscribe: 0,
+    forget_all: 'transaction',
 });

--- a/src/calls/unauthenticated.js
+++ b/src/calls/unauthenticated.js
@@ -46,10 +46,6 @@ export const unsubscribeFromAllPortfolios = () => ({
     forget_all: 'portfolio',
 });
 
-export const unsubscribeFromAllProposalsOpenContract = () => ({
-    forget_all: 'proposal_open_contract',
-});
-
 export const getLandingCompany = (landingCompany: string) => ({
     landing_company: landingCompany,
 });


### PR DESCRIPTION
`subscribe: 0` is deprecated (and actually does not work!), let's use `forget_all`.
Also deleted `unsubscribeFromAllProposalsOpenContract` because of redundancy with `unsubscribeFromAllOpenContracts` and also encapsulation. AFAIK it only affects [this](https://github.com/binary-com/binary-next-gen/blob/master/src/_data/LiveData.js) in next-gen.