### PR TITLE
salar / Fix: Do not raise socket connections errors

### DIFF
--- a/src/LiveApi.js
+++ b/src/LiveApi.js
@@ -97,9 +97,14 @@ export default class LiveApi {
         const urlPlusParams = `${this.apiUrl}?l=${this.language}&app_id=${this.appId}${optionalParam}`;
 
         Object.keys(this.unresolvedPromises).forEach(reqId => {
-            const disconnectedError = new Error('Websocket disconnected before response received.');
-            disconnectedError.name = 'DisconnectError';
-            this.unresolvedPromises[reqId].reject(disconnectedError);
+            /*
+            * Swallow connection errors, we can't do anything about them.
+            * Instead of raising, just log them to the console as a warning.
+            */
+            // const disconnectedError = new Error('Websocket disconnected before response received.');
+            // disconnectedError.name = 'DisconnectError';
+            // this.unresolvedPromises[reqId].reject(disconnectedError);
+            console.warn(`DisconnectError: Websocket disconnected before response received for req ID: ${reqId}.`);
             delete this.unresolvedPromises[reqId];
         });
 


### PR DESCRIPTION
Since we can not do anything regarding disconnected sockets except trying to establish a new one, we need to make the errors silent so they do not appear in TrackJS.
This is already in the code for the try/catch block but we're raising the rejected promises [here](https://github.com/binary-com/binary-live-api/blob/bca4fdc7ef246f5a71adc8176991c87d4506bad4/src/LiveApi.js#L102)
Their behavior should be like our try/catch which silently does nothing.
[try/catch code](https://github.com/binary-com/binary-live-api/blob/bca4fdc7ef246f5a71adc8176991c87d4506bad4/src/LiveApi.js#L109)